### PR TITLE
Add defend.network RSS feed to Synthesis category

### DIFF
--- a/tiny.opml
+++ b/tiny.opml
@@ -96,6 +96,7 @@
     </outline>
     <outline text="Synthesis" title="Synthesis">
       <outline htmlUrl="https://cxsecurity.com/wlb/rss/all/" xmlUrl="https://cxsecurity.com/wlb/rss/all/" title="CXSecurity: World Laboratory of Bugtraq 2" text="CXSecurity: World Laboratory of Bugtraq 2" type="rss" />
+      <outline text="defend.network" title="defend.network" type="rss" xmlUrl="https://defend.network/feed.xml" htmlUrl="https://defend.network" />
       <outline title="绿盟科技技术博客" htmlUrl="https://blog.nsfocus.net" type="rss" text="绿盟科技技术博客" xmlUrl="http://blog.nsfocus.net/feed/" />
       <outline type="rss" text="unSafe.sh - 不安全" htmlUrl="https://buaq.net/" xmlUrl="https://buaq.net/rss.xml" title="unSafe.sh - 不安全" />
       <outline title="安全客-有思想的安全新媒体" text="安全客-有思想的安全新媒体" type="rss" xmlUrl="https://api.anquanke.com/data/v1/rss" htmlUrl="https://www.anquanke.com" />


### PR DESCRIPTION
Add defend.network RSS feed to Synthesis category

**Feed URL:** https://defend.network/feed.xml
**Category:** Synthesis
**Site URL:** https://defend.network

defend.network publishes free daily AI-generated threat briefings and weekly vulnerability reports for security teams. Each briefing is structured by threat type (16 categories), affected industry (13 categories), and severity level, with action checklists and remediation guidance.

Sources include CISA advisories, vendor bulletins, and leading cybersecurity publications including The Hacker News, BleepingComputer, Krebs on Security, Dark Reading, and The Record.

High-signal feed — one structured briefing per day, actively maintained, good fit alongside SecurityWeek, The DFIR Report, and Microsoft Security Blog in the Synthesis category.

https://defend.network