### PR TITLE
Add ThreatCluster feeds

### DIFF
--- a/tiny.opml
+++ b/tiny.opml
@@ -517,5 +517,9 @@
       <outline type="rss" title="Dynomight" text="Dynomight" htmlUrl="https://dynomight.net/" xmlUrl="https://dynomight.net/feed.xml" />
       <outline type="rss" title="Chain Of Thought" text="Chain Of Thought" htmlUrl="https://vrungta.substack.com" xmlUrl="https://vrungta.substack.com/feed" />
     </outline>
+    <outline title="News" text="News">
+      <outline title="ThreatCluster" text="ThreatCluster" type="rss" xmlUrl="https://threatcluster.io/feed.xml" htmlUrl="https://threatcluster.io" />
+      <outline title="ThreatCluster Ransomware" text="ThreatCluster Ransomware" type="rss" xmlUrl="https://threatcluster.io/dark-web/feed.xml" htmlUrl="https://threatcluster.io/dark-web" />
+    </outline>
   </body>
 </opml>

--- a/tiny.opml
+++ b/tiny.opml
@@ -339,6 +339,8 @@
       <outline text="VulDB Recent Entries" title="VulDB Recent Entries" type="rss" xmlUrl="https://vuldb.com/en/?rss.recent" htmlUrl="" />
       <outline text="CERT Recently Published Vulnerability Notes" title="CERT Recently Published Vulnerability Notes" type="rss" xmlUrl="http://www.kb.cert.org/vulfeed" htmlUrl="" />
       <outline text="安全牛" title="安全牛" type="rss" xmlUrl="https://wechat2rss.xlab.app/feed/10f1ba549b70cdb4216f7ade606d30a813305aa1.xml" htmlUrl="" />
+      <outline title="ThreatCluster" text="ThreatCluster" type="rss" xmlUrl="https://threatcluster.io/feed.xml" htmlUrl="https://threatcluster.io" />
+      <outline title="ThreatCluster Ransomware" text="ThreatCluster Ransomware" type="rss" xmlUrl="https://threatcluster.io/dark-web/feed.xml" htmlUrl="https://threatcluster.io/dark-web" />
     </outline>
     <outline text="WebSecurity" title="WebSecurity">
       <outline xmlUrl="https://portswigger.net/research/rss" text="PortSwigger Research" type="rss" title="PortSwigger Research" htmlUrl="https://portswigger.net/research" />
@@ -516,10 +518,6 @@
       <outline type="rss" title="lcamtuf (Michal Zalewski)" text="lcamtuf (Michal Zalewski)" htmlUrl="https://lcamtuf.substack.com/" xmlUrl="https://lcamtuf.substack.com/feed" />
       <outline type="rss" title="Dynomight" text="Dynomight" htmlUrl="https://dynomight.net/" xmlUrl="https://dynomight.net/feed.xml" />
       <outline type="rss" title="Chain Of Thought" text="Chain Of Thought" htmlUrl="https://vrungta.substack.com" xmlUrl="https://vrungta.substack.com/feed" />
-    </outline>
-    <outline title="News" text="News">
-      <outline title="ThreatCluster" text="ThreatCluster" type="rss" xmlUrl="https://threatcluster.io/feed.xml" htmlUrl="https://threatcluster.io" />
-      <outline title="ThreatCluster Ransomware" text="ThreatCluster Ransomware" type="rss" xmlUrl="https://threatcluster.io/dark-web/feed.xml" htmlUrl="https://threatcluster.io/dark-web" />
     </outline>
   </body>
 </opml>


### PR DESCRIPTION
Two feeds under a new News category (happy to move them wherever fits better). Main feed is deduplicated threat clusters from 17,000+ sources, one entry per story instead of one per outlet. Second is ransomware leak site victims. Both stable, refreshed continuously.